### PR TITLE
Fix incorrect string literal highlight & incorrect indent style

### DIFF
--- a/ftplugin/v.vim
+++ b/ftplugin/v.vim
@@ -8,6 +8,7 @@ set cpo&vim
 
 " Here we tell vim what v language is like
 setlocal comments=://
+setlocal indentexpr=
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/syntax/v.vim
+++ b/syntax/v.vim
@@ -3,7 +3,7 @@ if exists('b:current_syntax')
 endif
 
 " Constant {{{
-syn match vString /'.*'/ contains=vInterpolation
+syn match vString /'.\{-}'/ contains=vInterpolation
 syn match vCharacter /`.`/ " FIXME: escaped char like `\n` wouldn't work so far
 syn match vNumber /[[:digit:]]\+/
 syn keyword vBoolean true false


### PR DESCRIPTION
This PR fix following bugs.

- Incorrect string literal highlight
If we write some codes like `typ == 'GET' && !curl.contains('?')`, current implementation will highlights `GET' && !curl.contains('?`.

- Incorrect indent style
Because V's extension is '.v', vim recognizes v files as Verilog files and use its indent style. This will cause wrong indentation like following.
```
fn main() {
	}
```